### PR TITLE
Travis CI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - tar -xvzf gsl-2.5.tar.gz
   - cd gsl-2.5
   - ./configure && make && sudo make install
+  - cd ..
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
 
+sudo: required
+
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+
+before_install:
+  - wget http://ftp.wrz.de/pub/gnu/gsl/gsl-2.5.tar.gz
+  - tar -xvzf gsl-2.5.tar.gz
+  - cd gsl-2.5
+  - ./configure && make && sudo make install
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
This fixes #13 and allows #12 to be merged without breaking the build. The issue was an outdated version of libgsl in the Ubuntu 14.04 package repository; the build script now downloads the sources and builds libgsl-2.5 before pip installing pygsl and starting the ode-toolbox tests.