### PR TITLE
Fix aeif_cond_alpha_implicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - tar -xvzf gsl-2.5.tar.gz
   - cd gsl-2.5
   - ./configure && make && sudo make install
+  - cd ..
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
 
+sudo: required
+
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+
+before_install:
+  - wget http://ftp.wrz.de/pub/gnu/gsl/gsl-2.5.tar.gz
+  - tar -xvzf gsl-2.5.tar.gz
+  - cd gsl-2.5
+  - ./configure && make && sudo make install
 
 install:
   - pip install -r requirements.txt

--- a/odetoolbox/stiffness.py
+++ b/odetoolbox/stiffness.py
@@ -55,7 +55,7 @@ numpy.random.seed(42)
 # these functions are called from the framework and cannot take these variables as parameters
 step_function_implementation = None
 jacobian_matrix_implementation = None
-parameters = {}
+parameters = globals().copy()
 
 
 def check_ode_system_for_stiffness(json_input):
@@ -83,7 +83,6 @@ def check_ode_system_for_stiffness(json_input):
 
     # `parameters` contains a series of variables from the differential equations declaration separated by the
     # newline they are defined in the global scope so that different functions can access them either
-    parameters = {}
     for variable in json_input["parameters"]:
         parameters[variable] = float(json_input["parameters"][variable])
 
@@ -500,6 +499,7 @@ def step(t, y, params):
     :return: Updated state vector stored in `f`
     """
     global step_function_implementation
+    global parameters
     dimension = len(y)
     # f is used in the step_function_implementation. since it is a return value of this function, it is declared here
     # explicitly

--- a/tests/test_ode_analyzer.py
+++ b/tests/test_ode_analyzer.py
@@ -80,6 +80,14 @@ class TestSolutionComputation(unittest.TestCase):
         self.assertTrue(len(result["propagator"]) > 0)
 
 
+    def test_aeif_cond_alpha_implicit(self):
+        indict = open_json("aeif_cond_alpha_implicit.json")
+        result = odetoolbox.analysis(indict)
+
+        self.assertEqual("analytical", result["solver"])
+        self.assertTrue(len(result["propagator"]) > 0)
+
+
     def test_iaf_psc_alpha_mixed(self):
         indict = open_json("iaf_psc_alpha_mixed.json")
         result = odetoolbox.analysis(indict)


### PR DESCRIPTION
This fixes #8. I was getting another error on `aeif_cond_alpha_implicit.json`, namely, that the exp (exponential) function could not be found. It turned out that all global functions (including those from the math module) are explicitly put into a dictionary and passed to an exec() call. `math.exp` was missing from this list. This PR fixes the issue and adds `aeif_cond_alpha_implicit.json` to the unit tests.