### PR TITLE
Add unit test for aeif_cond_alpha_implicit

### DIFF
--- a/odetoolbox/stiffness.py
+++ b/odetoolbox/stiffness.py
@@ -313,9 +313,10 @@ class StiffnessTester(object):
 
             threshold_crossed = False
             for threshold in self.thresholds:
+                _globals = self.math_module_funcs.copy()
                 local_parameters = self.parameters.copy()
                 local_parameters.update({"y__%i"%i: y for i,y in enumerate(y)})
-                if eval(threshold, local_parameters):
+                if eval(threshold, _globals, local_parameters):
                     threshold_crossed = True
                     break  # break inner loop
 
@@ -370,6 +371,8 @@ class StiffnessTester(object):
         Computes an numpy vector start values for the ode system.
         :return: Numpy-Vector with `dimension` elements
         """
+        _globals = self.math_module_funcs.copy()
+
         y = numpy.zeros(len(self.ode_definitions), numpy.float)
         for state_start_variable in self.state_start_values:
             matcher = re.compile(r".*(\d)+$")
@@ -378,7 +381,7 @@ class StiffnessTester(object):
             local_parameters = locals().copy()
             local_parameters.update(self.parameters)
 
-            y[oder_order_number] = eval(self.state_start_values[state_start_variable], local_parameters)
+            y[oder_order_number] = eval(self.state_start_values[state_start_variable], _globals, local_parameters)
         return y
 
 

--- a/tests/test_ode_analyzer.py
+++ b/tests/test_ode_analyzer.py
@@ -72,6 +72,14 @@ class TestSolutionComputation(unittest.TestCase):
         self.assertTrue(len(propagator.ode_updates) > 0)
 
 
+    def test_aeif_cond_alpha_implicit(self):
+        indict = open_json("aeif_cond_alpha_implicit.json")
+        result = odetoolbox.analysis(indict)
+
+        self.assertEqual("analytical", result["solver"])
+        self.assertTrue(len(result["propagator"]) > 0)
+
+
     def test_iaf_psc_alpha(self):
         indict = open_json("iaf_psc_alpha.json")
         result = odetoolbox.analysis(indict)

--- a/tests/test_stiffness.py
+++ b/tests/test_stiffness.py
@@ -47,31 +47,31 @@ class TestStiffnessChecker(unittest.TestCase):
         indict = open_json("iaf_cond_alpha_odes.json")
         tester = StiffnessTester(indict)
         result = tester.check_stiffness()
-        self.assertEquals("explicit", result)
+        self.assertEqual("explicit", result)
 
     def test_iaf_cond_alpha_odes_stiff(self):
         indict = open_json("iaf_cond_alpha_odes_stiff.json")
         tester = StiffnessTester(indict)
         result = tester.check_stiffness()
-        self.assertEquals("implicit", result)
+        self.assertEqual("implicit", result)
 
     def test_iaf_cond_alpha_odes_threshold(self):
         indict = open_json("iaf_cond_alpha_odes_threshold.json")
         tester = StiffnessTester(indict)
         result = tester.check_stiffness()
-        self.assertEquals("explicit", result)
+        self.assertEqual("explicit", result)
 
     def test_fitzhugh_nagumo(self):
         indict = open_json("fitzhugh_nagumo.json")
         tester = StiffnessTester(indict)
         result = tester.check_stiffness(sim_resolution=0.05, accuracy=1e-5)
-        self.assertEquals("explicit", result)
+        self.assertEqual("explicit", result)
 
     def test_morris_lecar(self):
         indict = open_json("morris_lecar.json")
         tester = StiffnessTester(indict)
         result = tester.check_stiffness(sim_resolution=0.2, accuracy=1e-5)
-        self.assertEquals("explicit", result)
+        self.assertEqual("explicit", result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes #8 and adds aeif_cond_alpha_implicit to the Travis CI environment.

Eliminates the use of `globals()` in favour of introspection, allowing more fine-grained control over the environment that gets passed to `eval()`.