### PR TITLE
Fix bug in function checking whether ODE is homogeneous

### DIFF
--- a/odetoolbox/shapes.py
+++ b/odetoolbox/shapes.py
@@ -169,8 +169,7 @@ class Shape():
             return True
 
         all_symbols = self.get_all_variable_symbols(shapes, derivative_symbol=differential_order_symbol)
-
-        for term in sympy.Add.make_args(self.diff_rhs_derivatives):
+        for term in sympy.Add.make_args(self.diff_rhs_derivatives.expand()):
             term_is_const = True
             for sym in all_symbols:
                 expr = sympy.diff(term, sym)

--- a/tests/test_homogeneous.py
+++ b/tests/test_homogeneous.py
@@ -32,13 +32,13 @@ class TestHomogeneous(unittest.TestCase):
     def test_homogeneous(self):
         shape_inh = Shape.from_function("I_in", "(e/tau_syn_in) * t * exp(-t/tau_syn_in)")
         shape_exc = Shape.from_function("I_ex", "(e/tau_syn_ex) * t * exp(-t/tau_syn_ex)")
-        shape_V_m = Shape.from_ode("V_m", "-V_m/Tau + (I_in + I_ex + I_e) / C_m", initial_values={"V_m" : "0."})
+        shape_V_m = Shape.from_ode("V_m", "-V_m/Tau + (I_in + I_ex + I_e) / C_m", initial_values={"V_m": "0."})
 
         self.assertTrue(shape_inh.is_homogeneous())
         self.assertTrue(shape_exc.is_homogeneous())
         self.assertFalse(shape_V_m.is_homogeneous(shapes=[shape_inh, shape_exc]))
 
-        shape_V_m = Shape.from_ode("V_m", "-V_m/Tau + (I_in + I_ex) / C_m", initial_values={"V_m" : "0."})
+        shape_V_m = Shape.from_ode("V_m", "-V_m/Tau + (I_in + I_ex) / C_m", initial_values={"V_m": "0."})
         self.assertTrue(shape_V_m.is_homogeneous(shapes=[shape_inh, shape_exc]))
         self.assertFalse(shape_V_m.is_homogeneous(shapes=[]))
 

--- a/tests/test_homogeneous.py
+++ b/tests/test_homogeneous.py
@@ -1,0 +1,47 @@
+#
+# test_homogeneous.py
+#
+# This file is part of the NEST ODE toolbox.
+#
+# Copyright (C) 2017 The NEST Initiative
+#
+# The NEST ODE toolbox is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# The NEST ODE toolbox is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import json
+import os
+import unittest
+
+from .context import odetoolbox
+from odetoolbox.shapes import Shape
+
+
+class TestHomogeneous(unittest.TestCase):
+
+    def test_homogeneous(self):
+        shape_inh = Shape.from_function("I_in", "(e/tau_syn_in) * t * exp(-t/tau_syn_in)")
+        shape_exc = Shape.from_function("I_ex", "(e/tau_syn_ex) * t * exp(-t/tau_syn_ex)")
+        shape_V_m = Shape.from_ode("V_m", "-V_m/Tau + (I_in + I_ex + I_e) / C_m", initial_values={"V_m" : "0."})
+
+        self.assertTrue(shape_inh.is_homogeneous())
+        self.assertTrue(shape_exc.is_homogeneous())
+        self.assertFalse(shape_V_m.is_homogeneous(shapes=[shape_inh, shape_exc]))
+
+        shape_V_m = Shape.from_ode("V_m", "-V_m/Tau + (I_in + I_ex) / C_m", initial_values={"V_m" : "0."})
+        self.assertTrue(shape_V_m.is_homogeneous(shapes=[shape_inh, shape_exc]))
+        self.assertFalse(shape_V_m.is_homogeneous(shapes=[]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_integration.json
+++ b/tests/test_integration.json
@@ -21,7 +21,7 @@
         "initial_value": "e / Tau_syn_gap"
     },
     {
-      "expression": "V_abs' = -V_abs/Tau + 1/C_m*(I_shape_in + I_shape_ex + I_shape_gap1 + I_e + currents)",
+      "expression": "V_abs' = -V_abs/Tau + (I_shape_in + I_shape_ex + I_shape_gap1) / C_m",
       "initial_value": "0."
     }
   ]


### PR DESCRIPTION
Notes for reviewers: the real bugfix is in ``odetoolbox/shapes.py``. The change in ``test_integration.json`` is something that should have been like this in the first place, but was missed (albeit without any further consequence) because of the bug. I added a unit test and checked that it fails without the fix in place.