### PR TITLE
Fix incorrect reference to sympy power function

### DIFF
--- a/odetoolbox/shapes.py
+++ b/odetoolbox/shapes.py
@@ -63,7 +63,7 @@ class Shape():
                       "Float": sympy.Float,
                       "Function": sympy.Function,
                       "Pow": sympy.Pow,
-                      "power": sympy.power,
+                      "power": sympy.Pow,
                       "exp": sympy.exp,
                       "log": sympy.log,
                       "sin": sympy.sin,


### PR DESCRIPTION
Sympy 1.7 was released 5 days ago. The API was changed as a part of this release, preventing "accidentally importable modules and names" from being imported any longer ([release notes](https://github.com/sympy/sympy/wiki/release-notes-for-1.7)). This revealed an incorrect reference to the ``power`` module rather than the power function (``Pow``).