### PR TITLE
Make use of _is_zero() consistent

### DIFF
--- a/odetoolbox/shapes.py
+++ b/odetoolbox/shapes.py
@@ -26,7 +26,7 @@ import re
 import sympy
 import sympy.parsing.sympy_parser
 
-from .sympy_printer import _is_sympy_type
+from .sympy_printer import _is_sympy_type, _is_zero
 
 
 class MalformedInputException(Exception):
@@ -164,7 +164,7 @@ class Shape():
         :rtype: bool
         """
 
-        if self.diff_rhs_derivatives.is_zero:
+        if _is_zero(self.diff_rhs_derivatives):
             # trivial case: right-hand side is zero
             return True
 
@@ -173,7 +173,7 @@ class Shape():
             term_is_const = True
             for sym in all_symbols:
                 expr = sympy.diff(term, sym)
-                if not sympy.sympify(expr).is_zero:
+                if not _is_zero(sympy.sympify(expr)):
                     # this term is of the form "sym * expr", hence it cannot be a constant term
                     term_is_const = False
 
@@ -244,15 +244,15 @@ class Shape():
         for sym in all_symbols:
             for df in self.derivative_factors:
                 expr = sympy.diff(df, sym)
-                if not sympy.sympify(expr).is_zero:
+                if not _is_zero(sympy.sympify(expr)):
                     # the expression "sym * self.symbol" appears on right-hand side of this shape's definition
                     return False
 
             expr = sympy.diff(self.diff_rhs_derivatives, sym)
-            if not sympy.sympify(expr).is_zero:
+            if not _is_zero(sympy.sympify(expr)):
                 # the variable symbol `sym` appears on right-hand side of this expression. Check to see if it appears as a linear term by checking whether taking its derivative again, with respect to any known variable, yields 0
                 for sym_ in all_symbols:
-                    if not sympy.sympify(sympy.diff(expr, sym_)).is_zero:
+                    if not _is_zero(sympy.sympify(sympy.diff(expr, sym_))):
                         return False
 
         return True
@@ -435,7 +435,7 @@ class Shape():
 
         t_val = None
         for t_ in range(0, max_t):
-            if not definition.subs(time_symbol, t_).is_zero:
+            if not _is_zero(definition.subs(time_symbol, t_)):
                 t_val = t_
                 break
 
@@ -461,7 +461,7 @@ class Shape():
 
         derivative_factors = [(1 / derivatives[0] * derivatives[1]).subs(time_symbol, t_val)]
         diff_rhs_lhs = derivatives[1] - derivative_factors[0] * derivatives[0]
-        found_ode = sympy.simplify(diff_rhs_lhs).is_zero
+        found_ode = _is_zero(sympy.simplify(diff_rhs_lhs))
 
 
         #
@@ -490,7 +490,7 @@ class Shape():
                     for j in range(order):
                         X[i, j] = derivatives[j].subs(time_symbol, substitute)
 
-                if not sympy.simplify(sympy.det(X)).is_zero:
+                if not _is_zero(sympy.simplify(sympy.det(X))):
                     invertible = True
                     break
 
@@ -519,7 +519,7 @@ class Shape():
                 diff_rhs_lhs -= derivative_factors[k] * derivatives[k]
             diff_rhs_lhs += derivatives[order]
 
-            if len(str(diff_rhs_lhs)) < Shape.EXPRESSION_SIMPLIFICATION_THRESHOLD and sympy.simplify(diff_rhs_lhs).is_zero:
+            if len(str(diff_rhs_lhs)) < Shape.EXPRESSION_SIMPLIFICATION_THRESHOLD and _is_zero(sympy.simplify(diff_rhs_lhs)):
                 found_ode = True
                 break
 

--- a/odetoolbox/stiffness.py
+++ b/odetoolbox/stiffness.py
@@ -51,7 +51,7 @@ except ImportError as ie:
     PYGSL_AVAILABLE = False
 
 
-class StiffnessTester(object):
+class StiffnessTester:
 
     def __init__(self, system_of_shapes, shapes, analytic_solver_dict=None, parameters=None, stimuli=None, random_seed=123, max_step_size=np.inf, integration_accuracy_abs=1E-6, integration_accuracy_rel=1E-6, sim_time=100., alias_spikes=False):
         r"""

--- a/odetoolbox/sympy_printer.py
+++ b/odetoolbox/sympy_printer.py
@@ -23,6 +23,19 @@ import sympy
 from sympy.printing import StrPrinter
 
 
+def _is_zero(x):
+    r"""
+    Check if a sympy expression is equal to zero.
+
+    In the ideal case, we would like to use sympy.simplify() to do simplification of an expression before comparing it to zero. However, for expressions of moderate size (e.g. a few dozen terms involving exp() functions), it becomes unbearably slow. We therefore use this internal function, so that the simplification function can be easily switched over.
+
+    Tests by expand_mul only, suitable for polynomials and rational functions.
+
+    Ref.: https://github.com/sympy/sympy PR #13877 by @normalhuman et al. merged on Jan 27, 2018
+    """
+    return bool(sympy.expand_mul(x).is_zero)
+
+
 def _is_sympy_type(var):
     # for sympy version <= 1.4.*
     try:

--- a/odetoolbox/system_of_shapes.py
+++ b/odetoolbox/system_of_shapes.py
@@ -27,20 +27,10 @@ import sympy
 import sympy.matrices
 
 from .shapes import Shape
+from .sympy_printer import _is_zero
 
 
-def _is_zero(x):
-    r"""
-    In the ideal case, we would like to use sympy.simplify() to do simplification of an expression before comparing it to zero. However, for expressions of moderate size (e.g. a few dozen terms involving exp() functions), it becomes unbearably slow. We therefore use this internal function, so that the simplification function can be easily switched over.
-
-    Tests by expand_mul only, suitable for polynomials and rational functions.
-
-    Ref.: https://github.com/sympy/sympy PR #13877 by @normalhuman et al. merged on Jan 27, 2018
-    """
-    return bool(sympy.expand_mul(x).is_zero)
-
-
-class SystemOfShapes(object):
+class SystemOfShapes:
     r"""
     Represent a dynamical system in the canonical form :math:`\mathbf{x}' = \mathbf{Ax} + \mathbf{c}`.
     """


### PR DESCRIPTION
Consistently use the helper function ``_is_zero()`` rather than sympy's built-in expression method ``is_zero()``, for reasons stated in the function's docstring.