### PR TITLE
Print min() and max() functions in lowercase

### DIFF
--- a/odetoolbox/sympy_printer.py
+++ b/odetoolbox/sympy_printer.py
@@ -56,3 +56,12 @@ class SympyPrinter(StrPrinter):
 
     def _print_Exp1(self, expr):
         return 'e'
+
+    def _print_Function(self, expr):
+        """
+        Overrides base class method to print min() and max() functions in lowercase.
+        """
+        if expr.func.__name__ in ["Min", "Max"]:
+            return expr.func.__name__.lower() + "(%s)" % self.stringify(expr.args, ", ")
+
+        return expr.func.__name__ + "(%s)" % self.stringify(expr.args, ", ")


### PR DESCRIPTION
This changed as a side effect of https://github.com/nest/ode-toolbox/pull/46/files#diff-1792ba7ef70a0059c3a323b0b7964e7b1c8df3e14848d8e46a48e280759d5625R81. All occurrences of the min() and max() functions in output expressions are now printed in lowercase, as before.