### PR TITLE
Revert to default PyPI pygsl version

### DIFF
--- a/.github/workflows/ode-toolbox-build.yml
+++ b/.github/workflows/ode-toolbox-build.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip pytest pycodestyle codecov pytest-cov
           python -m pip install -r requirements.txt
-          if [ "${{ matrix.with_gsl }}" == "1" ]; then wget "https://files.pythonhosted.org/packages/17/fc/9c11163f017a0d6877141d4d4edb619b0f05990d865caab840a2d0463581/pygsl-2.3.0.1.tar.gz" && mv -v pygsl-2.3.0.1.tar.gz pygsl-2.3.0.tar.gz && python -m pip install pygsl-2.3.0.tar.gz ; fi
+          if [ "${{ matrix.with_gsl }}" == "1" ]; then python -m pip install pygsl ; fi
           export PYTHON_VERSION=`python -c "import sys; print('.'.join(map(str, [sys.version_info.major, sys.version_info.minor])))"`
           echo "Python version detected:"
           echo $PYTHON_VERSION

--- a/.github/workflows/ode-toolbox-build.yml
+++ b/.github/workflows/ode-toolbox-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip pytest pycodestyle codecov pytest-cov
+          python -m pip install --upgrade pip pytest pycodestyle codecov pytest-cov wheel
           python -m pip install -r requirements.txt
           if [ "${{ matrix.with_gsl }}" == "1" ]; then python -m pip install pygsl ; fi
           export PYTHON_VERSION=`python -c "import sys; print('.'.join(map(str, [sys.version_info.major, sys.version_info.minor])))"`


### PR DESCRIPTION
Because newer versions of pip enforce package metadata more strictly, pygsl had been rendered uninstallable directly from pip. This has been fixed upstream (https://github.com/pygsl/pygsl/pull/6).

This PR removes the workaround on our side.