### PR TITLE
Add try..except around singularity detection

### DIFF
--- a/odetoolbox/singularity_detection.py
+++ b/odetoolbox/singularity_detection.py
@@ -24,6 +24,13 @@ import sympy
 import sympy.parsing.sympy_parser
 
 
+class SingularityDetectionException(Exception):
+    """
+    Thrown in case an error occurs while detecting singularities.
+    """
+    pass
+
+
 class SingularityDetection:
     r"""Singularity detection for generated propagator matrix.
 
@@ -147,8 +154,11 @@ class SingularityDetection:
         A : sympy.Matrix
             system matrix
         """
-        conditions = SingularityDetection._generate_singularity_conditions(P)
-        conditions = SingularityDetection._flatten_conditions(conditions)  # makes a list of conditions with each condition in the form of a dict
-        conditions = SingularityDetection._filter_valid_conditions(conditions, A)  # filters out the invalid conditions (invalid means those for which A is not defined)
+        try:
+            conditions = SingularityDetection._generate_singularity_conditions(P)
+            conditions = SingularityDetection._flatten_conditions(conditions)  # makes a list of conditions with each condition in the form of a dict
+            conditions = SingularityDetection._filter_valid_conditions(conditions, A)  # filters out the invalid conditions (invalid means those for which A is not defined)
+        except Exception as e:
+            raise SingularityDetectionException()
 
         return conditions

--- a/odetoolbox/system_of_shapes.py
+++ b/odetoolbox/system_of_shapes.py
@@ -195,12 +195,15 @@ class SystemOfShapes:
         if sympy.I in sympy.preorder_traversal(P):
             raise PropagatorGenerationException("The imaginary unit was found in the propagator matrix. This can happen if the dynamical system that was passed to ode-toolbox is unstable, i.e. one or more state variables will diverge to minus or positive infinity.")
 
-        condition = SingularityDetection.find_singularities(P, self.A_)
-        if condition:
-            logging.warning("Under certain conditions, the propagator matrix is singular (contains infinities).")
-            logging.warning("List of all conditions that result in a singular propagator:")
-            for cond in condition:
-                logging.warning("\t" + r" ∧ ".join([str(k) + " = " + str(v) for k, v in cond.items()]))
+        try:
+            condition = SingularityDetection.find_singularities(P, self.A_)
+            if condition:
+                logging.warning("Under certain conditions, the propagator matrix is singular (contains infinities).")
+                logging.warning("List of all conditions that result in a singular propagator:")
+                for cond in condition:
+                    logging.warning("\t" + r" ∧ ".join([str(k) + " = " + str(v) for k, v in cond.items()]))
+        except Exception as e:
+            logging.warning("Could not check the propagator matrix for singularities.")
 
         logging.debug("System of equations:")
         logging.debug("x = " + str(self.x_))

--- a/odetoolbox/system_of_shapes.py
+++ b/odetoolbox/system_of_shapes.py
@@ -30,7 +30,7 @@ import sympy.matrices
 
 from .config import Config
 from .shapes import Shape
-from .singularity_detection import SingularityDetection
+from .singularity_detection import SingularityDetection, SingularityDetectionException
 from .sympy_helpers import _custom_simplify_expr, _is_zero
 
 
@@ -202,7 +202,7 @@ class SystemOfShapes:
                 logging.warning("List of all conditions that result in a singular propagator:")
                 for cond in condition:
                     logging.warning("\t" + r" ∧ ".join([str(k) + " = " + str(v) for k, v in cond.items()]))
-        except Exception as e:
+        except SingularityDetectionException:
             logging.warning("Could not check the propagator matrix for singularities.")
 
         logging.debug("System of equations:")


### PR DESCRIPTION
Singularity detection can fail in case there are custom functions (like ``42 + foobar(x, y)``) in the input expressions. Add a try..except to keep this from crashing ODE-toolbox.