### PR TITLE
Add option to customise propagator variable name prefix

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -341,6 +341,10 @@ The following global options are defined. Note that all are typically formatted 
      - 999
      - float
      - Maximum step size during simulation (e.g. for stiffness testing solvers).
+   * - ``propagators_prefix``
+     - ``"__P"``
+     - string
+     - Generated propagator terms are given names of the form ``"<propagators_prefix>__<var_name_1>__<var_name_2>"``.
    * - ``differential_order_symbol``
      - :python:`"__d"`
      - string

--- a/odetoolbox/__init__.py
+++ b/odetoolbox/__init__.py
@@ -182,7 +182,7 @@ def _get_all_first_order_variables(indict) -> Iterable[str]:
     return variable_names
 
 
-def _analysis(indict, disable_stiffness_check: bool = False, disable_analytic_solver: bool = False, preserve_expressions: Union[bool, Iterable[str]] = False, simplify_expression: Optional[str] = None, log_level: Union[str, int] = logging.WARNING) -> Tuple[List[Dict], SystemOfShapes, List[Shape]]:
+def _analysis(indict, disable_stiffness_check: bool = False, disable_analytic_solver: bool = False, preserve_expressions: Union[bool, Iterable[str]] = False, log_level: Union[str, int] = logging.WARNING) -> Tuple[List[Dict], SystemOfShapes, List[Shape]]:
     r"""
     Like analysis(), but additionally returns ``shape_sys`` and ``shapes``.
 
@@ -201,9 +201,6 @@ def _analysis(indict, disable_stiffness_check: bool = False, disable_analytic_so
         return [], SystemOfShapes.from_shapes([]), []
 
     _read_global_config(indict)
-
-    if simplify_expression:
-        Config.config["simplify_expression"] = simplify_expression
 
     # copy parameters from the input and make sure keys are of type sympy.Symbol
     parameters = None
@@ -402,7 +399,7 @@ def _init_logging(log_level: Union[str, int] = logging.WARNING):
     logging.getLogger().setLevel(log_level)
 
 
-def analysis(indict, disable_stiffness_check: bool = False, disable_analytic_solver: bool = False, preserve_expressions: Union[bool, Iterable[str]] = False, simplify_expression: Optional[str] = None, log_level: Union[str, int] = logging.WARNING) -> List[Dict]:
+def analysis(indict, disable_stiffness_check: bool = False, disable_analytic_solver: bool = False, preserve_expressions: Union[bool, Iterable[str]] = False, log_level: Union[str, int] = logging.WARNING) -> List[Dict]:
     r"""
     The main entry point of the ODE-toolbox API.
 
@@ -410,7 +407,6 @@ def analysis(indict, disable_stiffness_check: bool = False, disable_analytic_sol
     :param disable_stiffness_check: Whether to perform stiffness checking.
     :param disable_analytic_solver: Set to True to return numerical solver recommendations, and no propagators, even for ODEs that are analytically tractable.
     :param preserve_expressions: Set to True, or a list of strings corresponding to individual variable names, to disable internal rewriting of expressions, and return same output as input expression where possible. Only applies to variables specified as first-order differential equations.
-    :param simplify_expression: For all expressions ``expr`` that are rewritten internally: the contents of this parameter string are evaluated with ``eval()`` in Python to obtain the final output expression. Override for custom expression simplification steps. Example: ``"sympy.logcombine(sympy.powsimp(sympy.expand(expr)))"``.
     :param log_level: Sets the logging threshold. Logging messages which are less severe than ``log_level`` will be ignored. Log levels can be provided as an integer or string, for example "INFO" (more messages) or "WARN" (fewer messages). For a list of valid logging levels, see https://docs.python.org/3/library/logging.html#logging-levels
 
     :return: The result of the analysis. For details, see https://ode-toolbox.readthedocs.io/en/latest/index.html#output
@@ -419,6 +415,5 @@ def analysis(indict, disable_stiffness_check: bool = False, disable_analytic_sol
                         disable_stiffness_check=disable_stiffness_check,
                         disable_analytic_solver=disable_analytic_solver,
                         preserve_expressions=preserve_expressions,
-                        simplify_expression=simplify_expression,
                         log_level=log_level)
     return d

--- a/odetoolbox/config.py
+++ b/odetoolbox/config.py
@@ -31,6 +31,7 @@ class Config:
         "input_time_symbol": "t",
         "output_timestep_symbol": "__h",
         "differential_order_symbol": "__d",
+        "propagators_prefix": "__P",
         "sim_time": 100E-3,
         "max_step_size": 999.,
         "integration_accuracy_abs": 1E-6,

--- a/odetoolbox/system_of_shapes.py
+++ b/odetoolbox/system_of_shapes.py
@@ -268,7 +268,7 @@ class SystemOfShapes:
             update_expr_terms = []
             for col in range(P_sym.shape[1]):
                 if not _is_zero(P[row, col]):
-                    sym_str = "__P__{}__{}".format(str(self.x_[row]), str(self.x_[col]))
+                    sym_str = Config().propagators_prefix + "__{}__{}".format(str(self.x_[row]), str(self.x_[col]))
                     P_sym[row, col] = sympy.parsing.sympy_parser.parse_expr(sym_str, global_dict=Shape._sympy_globals)
                     P_expr[sym_str] = P[row, col]
                     if row != col and not _is_zero(self.b_[col]):
@@ -284,7 +284,7 @@ class SystemOfShapes:
                     update_expr_terms.append(Config().output_timestep_symbol + " * " + str(self.b_[row]))
                 else:
                     particular_solution = -self.b_[row] / self.A_[row, row]
-                    sym_str = "__P__{}__{}".format(str(self.x_[row]), str(self.x_[row]))
+                    sym_str = Config().propagators_prefix + "__{}__{}".format(str(self.x_[row]), str(self.x_[row]))
                     update_expr_terms.append("-" + sym_str + " * " + str(self.x_[row]))    # remove the term (add its inverse) that would have corresponded to a homogeneous solution and that was added in the ``for col...`` loop above
                     update_expr_terms.append(sym_str + " * (" + str(self.x_[row]) + " - (" + str(particular_solution) + "))" + " + (" + str(particular_solution) + ")")
 


### PR DESCRIPTION
This is to support some code generation targets (such as GeNN; see https://github.com/genn-team/genn/pull/678) that do not allow variable names to start with an underscore.

Also remove the redundant ``simplfy_expression`` parameter to ``analysis()``, as it can and should be passed via the global configuration options in the input dictionary.