### PR TITLE
Update readthedocs to Ubuntu 24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-    os: ubuntu-20.04
+    os: ubuntu-24.04
     tools:
         python: "3.9"
 


### PR DESCRIPTION
Required as a current image (20.04) will be deprecated soon by ReadTheDocs.